### PR TITLE
Release v2.8.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[build]
-rustflags = ["-Ctarget-cpu=native"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-rustflags = ["-Ctarget-cpu=cortex-a53"]
-
-[net]
-git-fetch-with-cli = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,6 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-${{ matrix.platform.name }}-cargo-build-rust${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.platform.name }}-cargo-build-rust${{ env.RUST_VERSION }}-
 
       - name: Build release binary
         run: cargo build --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-clippy-rust${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-clippy-rust${{ env.RUST_VERSION }}-
 
       - name: Run Clippy (main crate)
         run: cargo clippy -p edgefirst-model --no-deps --all-targets -- -D warnings
@@ -150,7 +149,6 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-${{ matrix.platform.name }}-cargo-test-rust${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.platform.name }}-cargo-test-rust${{ env.RUST_VERSION }}-
 
       - name: Run unit tests with coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to EdgeFirst Model will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-03-10
+
+### Added
+
+- **Tracker-assisted instance segmentation recovery**: when tracking is enabled,
+  the decoder runs at a lower score threshold (`--track-score`, default 0.1) to
+  produce more candidate detections. ByteTrack promotes low-confidence detections
+  that match existing tracks, enabling recovery of temporarily occluded objects
+  while preserving mask-box alignment.
+- New `--track-score` / `TRACK_SCORE` parameter for decoder threshold when
+  tracking is enabled.
+- ARA-2 NPU runtime backend via `Runtime` trait abstraction, supporting
+  `.dvm` model files over `/var/run/ara2.sock`.
+- Unified model output topic (`rt/model/output`) combining boxes, masks, tracks,
+  and timing in a single CDR message.
+- General `--classes` / `CLASSES` label filter replacing the old `MASK_CLASSES`,
+  filtering both detection boxes and instance segmentation masks.
+- Tracy tracing spans for main loop pipeline stages (preprocess, invoke, decode,
+  tracker_update, zenoh_publish).
+- On-target integration tests with LLVM coverage instrumentation.
+- Three-phase CI architecture: unit tests on GitHub runners, hardware integration
+  tests on i.MX8M Plus EVK, coverage aggregation and SonarCloud reporting.
+
+### Changed
+
+- **Breaking**: replaced `--track-high-conf` / `TRACK_HIGH_CONF` with
+  `--track-score` / `TRACK_SCORE`. The existing `--threshold` now serves as
+  ByteTrack's new-track-creation threshold when tracking is enabled.
+- **Breaking**: replaced `--engine` / `ENGINE` with `--delegate` / `DELEGATE`
+  for TFLite delegate library path.
+- **Breaking**: replaced `MASK_CLASSES` with `CLASSES` for label filtering.
+- **Breaking**: legacy detection and mask topics are now disabled by default
+  (empty `DETECT_TOPIC` / `MASK_TOPIC`). Set to `rt/model/boxes2d` /
+  `rt/model/mask` to re-enable.
+- Rewrote inference pipeline using `edgefirst-tflite` with 3-tier preprocessing
+  (G2D DMA → planar deinterleave → input tensor copy).
+- Replaced `SupportedModel` with `ModelContext` for decoder configuration,
+  supporting auto-detection of model config from output tensor shapes.
+- Folded box coordinate normalization into quantization scale for ARA-2 DVM
+  models.
+- Updated edgefirst-hal 0.9.0 → 0.9.1 (backend selection and mask decoding
+  fixes).
+- Updated edgefirst-tracker 0.9.0 → 0.9.1.
+- Pinned Rust toolchain to 1.94.0 in all CI workflows with version-aware
+  cache keys to prevent proc-macro ABI mismatches.
+
+### Fixed
+
+- Post-tracker filtering now correctly aligns boxes, masks, and track IDs using
+  a shared `keep` mask before publishing. Previously, `.flatten()` on tracker
+  results silently dropped untracked entries, causing index misalignment.
+- G2D acceleration restored by forcing DMA tensor allocation for camera frames.
+- Clippy warnings in main.rs resolved.
+
+### Removed
+
+- `tflite_model.rs` and `rtm_model.rs` (replaced by unified `model.rs` with
+  `ModelContext` and `decode_outputs`).
+- `--track-high-conf` / `TRACK_HIGH_CONF` parameter (replaced by two-threshold
+  approach using `--track-score` and `--threshold`).
+- `MASK_CLASSES` parameter (replaced by `CLASSES`).
+
 ## [2.7.0] - 2026-02-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-model"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "ara2",
  "async-pidfd",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-tracker"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00daab036c188bc673d5e3a1d7ee8bb5afe4e650b0c20a6aabdc3a461afe3969"
+checksum = "6ba77fb75ad92fc3291e1b386218a1691ea95f3272dcb261f95a08d01b8b2be9"
 dependencies = [
  "enum_dispatch",
  "lapjv",
@@ -3753,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "EdgeFirst Model Node - AI inference service for EdgeFirst Percept
 repository = "https://github.com/EdgeFirstAI/model"
 homepage = "https://www.edgefirst.ai"
 license = "Apache-2.0"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2024"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ edgefirst-hal = "0.9.1"
 edgefirst-tflite = { version = "0.1.0", features = ["full"] }
 four-char-code = "2.3.0"
 edgefirst-schemas = "1.5.5"
-edgefirst-tracker = "0.9.0"
+edgefirst-tracker = "0.9.1"
 log = { version = "0.4.28" }
 ndarray = { version = "0.16.1", features = ["rayon"] }
 nix = { version = "0.30.1", features = ["time"] }

--- a/NOTICE
+++ b/NOTICE
@@ -13,7 +13,7 @@ that require attribution:
   * edgefirst-hal 0.9.1 (Apache-2.0)
   * edgefirst-schemas 1.5.5 (Apache-2.0)
   * edgefirst-tflite 0.1.0 (Apache-2.0)
-  * edgefirst-tracker 0.9.0 (Apache-2.0)
+  * edgefirst-tracker 0.9.1 (Apache-2.0)
   * fast-math 0.1.1 (MIT OR Apache-2.0)
   * four-char-code 2.3.0 (MIT)
   * libc 0.2.183 (MIT OR Apache-2.0)


### PR DESCRIPTION
## Summary

Release preparation for EdgeFirst Model v2.8.0.

### Highlights

- **Tracker-assisted instance segmentation**: two-threshold approach (`--track-score` + `--threshold`) enables recovery of temporarily occluded objects while preserving mask-box alignment
- **ARA-2 NPU runtime**: new backend supporting `.dvm` models via Runtime trait abstraction
- **Unified model output**: single `rt/model/output` topic combining boxes, masks, tracks, and timing
- **Rewritten inference pipeline**: `edgefirst-tflite` with G2D DMA preprocessing and planar deinterleave
- **CI hardening**: pinned Rust 1.94.0 toolchain, version-aware cache keys, on-target integration tests

### Breaking Changes

| Old | New |
|-----|-----|
| `--track-high-conf` / `TRACK_HIGH_CONF` | `--track-score` / `TRACK_SCORE` + reuse of `--threshold` |
| `--engine` / `ENGINE` | `--delegate` / `DELEGATE` |
| `MASK_CLASSES` | `CLASSES` |
| `DETECT_TOPIC="rt/model/boxes2d"` | `DETECT_TOPIC=""` (disabled by default) |

### Release Checklist

- [x] Version bumped to 2.8.0 in Cargo.toml
- [x] CHANGELOG.md updated with all changes since v2.7.0
- [x] NOTICE file updated (edgefirst-tracker 0.9.1)
- [x] `cargo update` run for latest compatible versions
- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI passes (build, test, SBOM, clippy, format)
- [ ] Tag `v2.8.0` after merge