### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to EdgeFirst Model will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-05-23
+
+### Added
+
+- **Neutron NPU support for i.MX 95**: `TfLiteRuntime` scans loaded models for
+  the Neutron custom op and auto-selects between `libneutron_delegate.so` and
+  `libvx_delegate.so` (i.MX 8M Plus). Verified at 8 detections @ threshold 0.1
+  with zero-copy enabled on i.MX 95 hardware.
+- **Aspect-preserving letterboxing**: preprocessing now letterboxes camera
+  frames into the model input instead of stretching to fit. Detection boxes
+  and instance masks are back-projected through the letterbox transform so
+  published coordinates remain aligned to the original camera frame.
+- Support for the `edgefirst.json` embedded model config used by
+  Neutron-compiled models, in addition to the existing `edgefirst.yaml`.
+- Full DMA-BUF zero-copy input pipeline across all three runtimes — the HAL
+  `ImageProcessor` writes preprocessed pixels directly into the delegate input
+  buffer, with explicit `sync_input_for_device` / `sync_outputs_for_cpu`
+  cache flushes around inference.
+
+### Changed
+
+- Upgraded core dependencies: `edgefirst-hal` 0.9 → 0.23,
+  `edgefirst-tflite` 0.1 → 0.7, `edgefirst-tracker` 0.9 → 0.23,
+  and `ara2` to 0.10.
+- Output decoding migrated to the dtype-dispatching `Decoder::decode` over
+  `TensorDyn`. Box coordinate normalization is now handled by
+  `DecoderBuilder::with_input_dims`, replacing the legacy
+  `1/input_dim` scale-fold hack. Per-tensor quantization is attached to each
+  integer output so the Neutron per-scale decoder consumes the right scales.
+- Forced the G2D image backend for preprocessing. The HAL 0.23 threaded
+  OpenGL backend uses `tokio::mpsc::blocking_send`, which panics under the
+  service's tokio runtime; G2D is synchronous and avoids the issue.
+- **Cross-compilation now uses `cargo zigbuild`** (with `cargo-zigbuild` and
+  `zig` installed) instead of `cargo build --target ...`. The previous
+  `.cargo/config.toml` cross-linker stanza has been removed; plain
+  `cargo build --target aarch64-unknown-linux-gnu` will no longer link.
+  See `.github/copilot-instructions.md` for the updated setup.
+
+### Fixed
+
+- Validate delegate-returned DMA-BUF file descriptors before
+  `BorrowedFd::borrow_raw` and fail loudly on staging/input size mismatches,
+  preventing silent corruption when the delegate hands back an unexpected
+  buffer.
+- The `CameraAdaptor` RGBA fast path is now gated on `has_dmabuf`, so it
+  is not advertised when the CPU staging buffer cannot honor it.
+- Repository clones no longer fail on missing Git LFS objects: the
+  benchmark data files referenced LFS blobs that were never pushed to the
+  remote.
+
+### Removed
+
+- Benchmark data files in `benches/benchmark_data/` and the associated
+  `.gitattributes` LFS tracking rules.
+
 ## [2.8.0] - 2026-03-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-model"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "ara2",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "EdgeFirst Model Node - AI inference service for EdgeFirst Percept
 repository = "https://github.com/EdgeFirstAI/model"
 homepage = "https://www.edgefirst.ai"
 license = "Apache-2.0"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
## Summary

Release 2.9.0 of EdgeFirst Model. Headline changes since [2.8.0](https://github.com/EdgeFirstAI/model/releases/tag/v2.8.0):

- **Neutron NPU support for i.MX 95** alongside the existing VX delegate path for i.MX 8M Plus. `TfLiteRuntime` scans loaded models for the Neutron custom op and auto-selects between `libneutron_delegate.so` and `libvx_delegate.so`.
- **Aspect-preserving letterboxing** during preprocessing, replacing stretch-to-fit. Detection boxes and instance masks are back-projected through the letterbox transform so published coordinates remain aligned to the original camera frame.
- **`edgefirst.json` embedded config support** for Neutron-compiled models, in addition to the existing `edgefirst.yaml`.
- **Full DMA-BUF zero-copy input pipeline** across TFLite, Neutron and ARA-2 runtimes, with explicit cache flushes around inference.
- **HAL stack upgrade**: `edgefirst-hal` 0.9 → 0.23, `edgefirst-tflite` 0.1 → 0.7, `edgefirst-tracker` 0.9 → 0.23, `ara2` to 0.10.
- **Build system**: cross-compilation now uses `cargo zigbuild`; the old `.cargo/config.toml` cross-linker stanza has been removed (plain `cargo build --target ...` no longer links).
- **Fix**: removed benchmark data files that referenced never-pushed Git LFS objects and broke fresh clones.

No user-facing CLI or config breaking changes since 2.8.0 — internal-only HAL refactors.

See [CHANGELOG.md](CHANGELOG.md) for the complete entry.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-features -- -D warnings` — clean against CI's pinned Rust 1.94.0 toolchain
- `cargo test --all-features` — 11 unit tests pass; 2 hardware integration tests ignored (run on-target in CI)
- `cargo build --release` — version 2.9.0, builds clean

On-target verification from the EDGEAI-1311 work that landed for this release:
- i.MX 8M Plus VX delegate: 10 FPS sustained
- i.MX 95 Neutron delegate: 8 detections @ threshold 0.1, zero-copy enabled

## Release checklist

- [x] Version bumped in `Cargo.toml` (2.8.0 → 2.9.0)
- [x] `Cargo.lock` regenerated with new version
- [x] `CHANGELOG.md` updated with `[2.9.0] - 2026-05-23` section
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (CI toolchain)
- [x] `cargo test --all-features` passes
- [x] `cargo build --release` succeeds
- [ ] **2 approvals required** for merge to `main` (per SPS policy)
- [ ] After merge: `git tag -s v2.9.0` and `git push --tags` to trigger release workflow

## Test plan

- [ ] CI build matrix passes (x86_64 + aarch64 zigbuild)
- [ ] SBOM workflow generates clean license report
- [ ] On-target hardware tests pass on i.MX 8M Plus EVK
- [ ] After merge, tag `v2.9.0` triggers release artifact build